### PR TITLE
Set a fixed Node version in Dockerfile

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,67 @@
+name: PR actions
+'on':
+  pull_request:
+    branches:
+      - master
+jobs:
+  danger-ci:
+    name: Danger CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 16.x
+        env:
+          RUNNER_TEMP: /tmp
+      - name: Danger CI
+        uses: vtex/danger@master
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          REQUIRE_CHANGELOG_VERSION: false
+  io-app-test:
+    name: IO app test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+        env:
+          RUNNER_TEMP: /tmp
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: '${{ steps.yarn-cache-dir-path.outputs.dir }}'
+          key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Run test on every builder directory
+        uses: vtex/action-io-app-test@master
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+        env:
+          RUNNER_TEMP: /tmp
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: '${{ steps.yarn-cache-dir-path.outputs.dir }}'
+          key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+      - name: Lint project
+        uses: vtex/action-lint@master

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 12.x
+          node-version: 16.x
         env:
           RUNNER_TEMP: /tmp
       - name: Get yarn cache directory path
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Run test on every builder directory
-        uses: vtex/action-io-app-test@master
+        uses: ./
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,21 +4,6 @@ name: PR actions
     branches:
       - master
 jobs:
-  danger-ci:
-    name: Danger CI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
-        with:
-          node-version: 16.x
-        env:
-          RUNNER_TEMP: /tmp
-      - name: Danger CI
-        uses: vtex/danger@master
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          REQUIRE_CHANGELOG_VERSION: false
   io-app-test:
     name: IO app test
     runs-on: ubuntu-latest
@@ -41,27 +26,3 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Run test on every builder directory
         uses: ./
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
-        with:
-          node-version: 12.x
-        env:
-          RUNNER_TEMP: /tmp
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
-      - uses: actions/cache@v1
-        id: yarn-cache
-        with:
-          path: '${{ steps.yarn-cache-dir-path.outputs.dir }}'
-          key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: yarn install
-        run: yarn install --frozen-lockfile
-      - name: Lint project
-        uses: vtex/action-lint@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # You can specify a version:
 # FROM node:10-slim
-FROM node:slim
+FROM node:16-slim
 
 # Labels for GitHub to read your action
 LABEL "com.github.actions.name"="VTEX IO Test Action"


### PR DESCRIPTION
We're currently using the latest `node-slim` image available each time the Docker image for this action gets built. This is harder to maintain, since we are always getting silent updates in Node, including major releases. Recently, we've noticed this action failing in all repos that actually contain tests, probably due to some change in the latest Node version.

Since VTEX IO has a set fixed Node major, we don't need to keep using the latest available version in this action, and can default to using Node 16.x.

Also, this PR adds this action to the repo, so any new PRs will always use the action's code from the branch you're trying to merge into master.